### PR TITLE
feat: Monotonic Clock for MVCC Row Columns.

### DIFF
--- a/dbkernel/internal/memtable/utils.go
+++ b/dbkernel/internal/memtable/utils.go
@@ -1,10 +1,28 @@
 package memtable
 
 import (
+	"time"
+
 	"github.com/ankur-anand/unisondb/dbkernel/internal"
 	"github.com/ankur-anand/unisondb/internal/logcodec"
 	"github.com/dgraph-io/badger/v4/y"
 )
+
+type tsGenerator struct {
+	lastTS uint64
+}
+
+func (g *tsGenerator) Next() uint64 {
+	now := uint64(time.Now().UnixNano())
+	// UnixNano() may not return a strictly increasing value in fast loops,
+	if now <= g.lastTS {
+		// ensure strictly increasing
+		g.lastTS++
+	} else {
+		g.lastTS = now
+	}
+	return g.lastTS
+}
 
 // BuildColumnMap builds the columns from the provided mem-table entries.
 // it modifies the provided columnEntries with the entries fetched from mem table.

--- a/dbkernel/internal/memtable/utils_test.go
+++ b/dbkernel/internal/memtable/utils_test.go
@@ -1,0 +1,25 @@
+package memtable
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMonotonicClock(t *testing.T) {
+	// this denotes we have not
+	pTSMap := make(map[int64]struct{})
+	for i := 0; i < 100; i++ {
+		pTSMap[time.Now().UnixNano()] = struct{}{}
+	}
+
+	t.Logf("loop faster than unix nano? if len not 100 len: %d", len(pTSMap))
+	ts := &tsGenerator{}
+	prev := uint64(0)
+	for i := 0; i < 100; i++ {
+		now := ts.Next()
+		assert.Greater(t, now, prev)
+		now = prev
+	}
+}


### PR DESCRIPTION
UnixNano() may not return a strictly increasing value in fast loops. Espically during the TXN commit.