### PR TITLE
feat: channel based wait for append.

### DIFF
--- a/dbkernel/engine_test.go
+++ b/dbkernel/engine_test.go
@@ -194,6 +194,7 @@ func TestArenaReplacement_Snapshot_And_Recover(t *testing.T) {
 	// OpsFlushed and pause flush.
 	engine.fSyncStore()
 	engine.pauseFlush()
+	time.Sleep(100 * time.Millisecond)
 	_, err = engine.BtreeSnapshot(f)
 	assert.NoError(t, err)
 	err = f.Close()

--- a/internal/benchtests/broadcast/bench/ctxtimeout/main_test.go
+++ b/internal/benchtests/broadcast/bench/ctxtimeout/main_test.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/brianvoe/gofakeit/v7"
+)
+
+var (
+	globalResult []byte
+)
+
+func TestMain(m *testing.M) {
+
+	runtime.GOMAXPROCS(runtime.NumCPU())
+	runtime.LockOSThread()
+
+	result := m.Run()
+
+	runtime.UnlockOSThread()
+	os.Exit(result)
+}
+
+type benchConfig struct {
+	name         string
+	numGoroutine int
+	timeout      time.Duration
+}
+
+func getConfigs() []benchConfig {
+	return []benchConfig{
+		{name: "config-100-1s", numGoroutine: 100, timeout: 1 * time.Second},
+		{name: "config-1000-1s", numGoroutine: 1000, timeout: 1 * time.Second},
+		{name: "config-5000-1s", numGoroutine: 5000, timeout: 1 * time.Second},
+		{name: "config-10000-1s", numGoroutine: 10000, timeout: 1 * time.Second},
+	}
+}
+
+// simulateWALIO simulates I/O operations returning some bytes
+func simulateWALIO() []byte {
+	data := make([]byte, 36) // UUID length
+	copy(data, gofakeit.UUID())
+	return data
+}
+
+func BenchmarkSyncCond(b *testing.B) {
+	configs := getConfigs()
+	for _, cfg := range configs {
+		b.Run(cfg.name, func(b *testing.B) {
+			var mu sync.Mutex
+			cond := sync.NewCond(&mu)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				ctx, cancel := context.WithTimeout(context.Background(), cfg.timeout)
+				var wg sync.WaitGroup
+				var ready sync.WaitGroup
+				wg.Add(cfg.numGoroutine)
+				ready.Add(cfg.numGoroutine)
+
+				errCh := make(chan error, cfg.numGoroutine)
+
+				for j := 0; j < cfg.numGoroutine; j++ {
+					go func() {
+						defer wg.Done()
+						mu.Lock()
+						ready.Done()
+
+						done := make(chan struct{})
+						go func() {
+							cond.Wait()
+							close(done)
+						}()
+
+						select {
+						case <-ctx.Done():
+							mu.Unlock()
+							errCh <- ctx.Err()
+							return
+						case <-done:
+							result := simulateWALIO()
+							globalResult = result
+							mu.Unlock()
+							errCh <- nil
+							return
+						}
+					}()
+				}
+
+				ready.Wait()
+
+				mu.Lock()
+				cond.Broadcast()
+				mu.Unlock()
+
+				wg.Wait()
+				close(errCh)
+
+				timeouts := 0
+				for err := range errCh {
+					if errors.Is(err, context.DeadlineExceeded) {
+						timeouts++
+					}
+				}
+
+				cancel()
+			}
+		})
+	}
+}
+
+func BenchmarkBufferedChannel(b *testing.B) {
+	configs := getConfigs()
+	for _, cfg := range configs {
+		b.Run(cfg.name, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				ctx, cancel := context.WithTimeout(context.Background(), cfg.timeout)
+				ch := make(chan struct{}, 1)
+				var wg sync.WaitGroup
+				var ready sync.WaitGroup
+				wg.Add(cfg.numGoroutine)
+				ready.Add(cfg.numGoroutine)
+
+				errCh := make(chan error, cfg.numGoroutine)
+
+				for j := 0; j < cfg.numGoroutine; j++ {
+					go func() {
+						defer wg.Done()
+						ready.Done()
+
+						select {
+						case <-ctx.Done():
+							errCh <- ctx.Err()
+							return
+						case <-ch:
+							result := simulateWALIO()
+							globalResult = result
+							errCh <- nil
+						}
+					}()
+				}
+
+				ready.Wait()
+
+				for j := 0; j < cfg.numGoroutine; j++ {
+					select {
+					case <-ctx.Done():
+						goto cleanup
+					case ch <- struct{}{}:
+					}
+				}
+
+			cleanup:
+
+				wg.Wait()
+				close(ch)
+				close(errCh)
+
+				timeouts := 0
+				for err := range errCh {
+					if errors.Is(err, context.DeadlineExceeded) {
+						timeouts++
+					}
+				}
+
+				cancel()
+			}
+		})
+	}
+}
+
+func BenchmarkChannelCloseBroadcast(b *testing.B) {
+	configs := getConfigs()
+	for _, cfg := range configs {
+		b.Run(cfg.name, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				ctx, cancel := context.WithTimeout(context.Background(), cfg.timeout)
+				ch := make(chan struct{})
+				var wg sync.WaitGroup
+				var ready sync.WaitGroup
+				wg.Add(cfg.numGoroutine)
+				ready.Add(cfg.numGoroutine)
+
+				errCh := make(chan error, cfg.numGoroutine)
+
+				for j := 0; j < cfg.numGoroutine; j++ {
+					go func() {
+						defer wg.Done()
+						ready.Done()
+
+						select {
+						case <-ctx.Done():
+							errCh <- ctx.Err()
+							return
+						case <-ch:
+							result := simulateWALIO()
+							globalResult = result
+							errCh <- nil
+						}
+					}()
+				}
+
+				ready.Wait()
+
+				select {
+				case <-ctx.Done():
+					close(ch)
+				default:
+					close(ch)
+				}
+
+				wg.Wait()
+				close(errCh)
+
+				timeouts := 0
+				for err := range errCh {
+					if errors.Is(err, context.DeadlineExceeded) {
+						timeouts++
+					}
+				}
+				
+				cancel()
+			}
+		})
+	}
+}

--- a/internal/benchtests/broadcast/bench/nonctxtimeout/bench_test.go
+++ b/internal/benchtests/broadcast/bench/nonctxtimeout/bench_test.go
@@ -1,0 +1,206 @@
+package nonctxtimeout
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v7"
+)
+
+func TestMain(m *testing.M) {
+	runtime.GOMAXPROCS(runtime.NumCPU())
+	runtime.LockOSThread()
+
+	result := m.Run()
+
+	runtime.UnlockOSThread()
+	os.Exit(result)
+}
+
+var (
+	globalResult []byte
+)
+
+type benchConfig struct {
+	name         string
+	numGoroutine int
+}
+
+// getConfigs returns the benchmark configurations
+func getConfigs() []benchConfig {
+	configs := []benchConfig{
+		{name: "config-100", numGoroutine: 100},
+		{name: "config-1000", numGoroutine: 1000},
+		{name: "config-5000", numGoroutine: 5000},
+		{name: "config-10000", numGoroutine: 10000},
+	}
+	return configs
+}
+
+func simulateWALIO() []byte {
+	data := make([]byte, 36) // UUID length
+	copy(data, gofakeit.UUID())
+	return data
+}
+
+func BenchmarkSyncCond(b *testing.B) {
+	configs := getConfigs()
+	for _, cfg := range configs {
+		b.Run(cfg.name, func(b *testing.B) {
+			var mu sync.Mutex
+			cond := sync.NewCond(&mu)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				var wg sync.WaitGroup
+				var ready sync.WaitGroup
+				wg.Add(cfg.numGoroutine)
+				ready.Add(cfg.numGoroutine)
+
+				for j := 0; j < cfg.numGoroutine; j++ {
+					go func() {
+						defer wg.Done()
+						mu.Lock()
+						ready.Done()
+						for {
+							select {
+							case <-ctx.Done():
+								mu.Unlock()
+								return
+							default:
+								cond.Wait()
+								result := simulateWALIO()
+								globalResult = result
+								mu.Unlock()
+								return
+							}
+						}
+					}()
+				}
+
+				ready.Wait()
+
+				mu.Lock()
+				cond.Broadcast()
+				mu.Unlock()
+
+				wg.Wait()
+			}
+		})
+	}
+}
+
+func BenchmarkBufferedChannel(b *testing.B) {
+	configs := getConfigs()
+	for _, cfg := range configs {
+		b.Run(cfg.name, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				ch := make(chan struct{}, 1)
+				var wg sync.WaitGroup
+				var ready sync.WaitGroup
+				wg.Add(cfg.numGoroutine)
+				ready.Add(cfg.numGoroutine)
+
+				for j := 0; j < cfg.numGoroutine; j++ {
+					go func() {
+						defer wg.Done()
+						ready.Done()
+						<-ch
+						result := simulateWALIO()
+						globalResult = result
+					}()
+				}
+
+				ready.Wait()
+
+				for j := 0; j < cfg.numGoroutine; j++ {
+					ch <- struct{}{}
+				}
+
+				wg.Wait()
+				close(ch)
+			}
+		})
+	}
+}
+
+func BenchmarkUnbufferedChannel(b *testing.B) {
+	configs := getConfigs()
+	for _, cfg := range configs {
+		b.Run(cfg.name, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				ch := make(chan struct{})
+				var wg sync.WaitGroup
+				var ready sync.WaitGroup
+				wg.Add(cfg.numGoroutine)
+				ready.Add(cfg.numGoroutine)
+
+				for j := 0; j < cfg.numGoroutine; j++ {
+					go func() {
+						defer wg.Done()
+						ready.Done()
+						<-ch
+						result := simulateWALIO()
+						globalResult = result
+					}()
+				}
+
+				ready.Wait()
+
+				for j := 0; j < cfg.numGoroutine; j++ {
+					ch <- struct{}{}
+				}
+
+				wg.Wait()
+				close(ch)
+			}
+		})
+	}
+}
+
+func BenchmarkChannelCloseBroadcast(b *testing.B) {
+	configs := getConfigs()
+	for _, cfg := range configs {
+		b.Run(cfg.name, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				ch := make(chan struct{})
+				var wg sync.WaitGroup
+				var ready sync.WaitGroup
+				wg.Add(cfg.numGoroutine)
+				ready.Add(cfg.numGoroutine)
+
+				for j := 0; j < cfg.numGoroutine; j++ {
+					go func() {
+						defer wg.Done()
+						ready.Done()
+						<-ch
+						result := simulateWALIO()
+						globalResult = result
+					}()
+				}
+
+				ready.Wait()
+
+				close(ch)
+
+				wg.Wait()
+			}
+		})
+	}
+}


### PR DESCRIPTION
Moving Away from Sync.Cond to Channel closed for wait for append.

While Sync.Cond is much faster for normal scenarios. It doesn't suppot timeout as well.

To support timeout, goroutine needed to be spawned, which could result into go-routine leak if frequent timeout happens and no Broadcast if initiated.

In timeout scenarios: the benchmark number are not supportive of using sync.Cond.

While buffer channel had a slight edge, we kept notification on close channel, to make the API as Sync.

```
goos: darwin
goarch: arm64
pkg: github.com/ankur-anand/unisondb/internal/benchtests/broadcast/bench/nonctxtimeout
cpu: Apple M2 Pro
BenchmarkSyncCond/config-100-10      	    6326	    188666 ns/op	   16116 B/op	     302 allocs/op
BenchmarkSyncCond/config-1000-10     	     700	   1684640 ns/op	  162005 B/op	    3022 allocs/op
BenchmarkSyncCond/config-5000-10     	     139	   8618226 ns/op	  849513 B/op	   15512 allocs/op
BenchmarkSyncCond/config-10000-10    	      67	  17471277 ns/op	 1660389 B/op	   30624 allocs/op
BenchmarkBufferedChannel/config-100-10         	    4057	    294005 ns/op	   12975 B/op	     303 allocs/op
BenchmarkBufferedChannel/config-1000-10        	     471	   2538736 ns/op	  129038 B/op	    3012 allocs/op
BenchmarkBufferedChannel/config-5000-10        	      92	  12795087 ns/op	  658053 B/op	   15189 allocs/op
BenchmarkBufferedChannel/config-10000-10       	      46	  25653541 ns/op	 1424806 B/op	   31479 allocs/op
BenchmarkUnbufferedChannel/config-100-10       	    3943	    283752 ns/op	   12979 B/op	     303 allocs/op
BenchmarkUnbufferedChannel/config-1000-10      	     466	   2548488 ns/op	  128858 B/op	    3010 allocs/op
BenchmarkUnbufferedChannel/config-5000-10      	      93	  12811750 ns/op	  669040 B/op	   15304 allocs/op
BenchmarkUnbufferedChannel/config-10000-10     	      45	  25718239 ns/op	 1390407 B/op	   31151 allocs/op
BenchmarkChannelCloseBroadcast/config-100-10   	    3999	    300553 ns/op	   12987 B/op	     303 allocs/op
BenchmarkChannelCloseBroadcast/config-1000-10  	     466	   2553162 ns/op	  129119 B/op	    3013 allocs/op
BenchmarkChannelCloseBroadcast/config-5000-10  	     100	  12652615 ns/op	  668109 B/op	   15294 allocs/op
BenchmarkChannelCloseBroadcast/config-10000-10 	      46	  25416548 ns/op	 1398503 B/op	   31235 allocs/op
PASS
ok  	github.com/ankur-anand/unisondb/internal/benchtests/broadcast/bench/nonctxtimeout

```

```
goos: darwin
goarch: arm64
pkg: github.com/ankur-anand/unisondb/internal/benchtests/broadcast/bench/ctxtimeout
cpu: Apple M2 Pro
BenchmarkSyncCond/config-100-1s-10   	    3669	    326808 ns/op	   32173 B/op	     511 allocs/op
BenchmarkSyncCond/config-1000-1s-10  	     393	   3277142 ns/op	  335826 B/op	    5246 allocs/op
BenchmarkSyncCond/config-5000-1s-10  	      63	  16380576 ns/op	 1790971 B/op	   27382 allocs/op
BenchmarkSyncCond/config-10000-1s-10 	      31	  36073587 ns/op	 3641354 B/op	   55324 allocs/op
BenchmarkBufferedChannel/config-100-1s-10         	    4316	    301795 ns/op	   18476 B/op	     310 allocs/op
BenchmarkBufferedChannel/config-1000-1s-10        	     416	   2875769 ns/op	  179426 B/op	    3035 allocs/op
BenchmarkBufferedChannel/config-5000-1s-10        	      82	  14461461 ns/op	  921958 B/op	   15420 allocs/op
BenchmarkBufferedChannel/config-10000-1s-10       	      43	  29749215 ns/op	 1983891 B/op	   32295 allocs/op
BenchmarkChannelCloseBroadcast/config-100-1s-10   	    4156	    324396 ns/op	   18482 B/op	     310 allocs/op
BenchmarkChannelCloseBroadcast/config-1000-1s-10  	     414	   2952011 ns/op	  179144 B/op	    3032 allocs/op
BenchmarkChannelCloseBroadcast/config-5000-1s-10  	      84	  14623053 ns/op	  924760 B/op	   15449 allocs/op
BenchmarkChannelCloseBroadcast/config-10000-1s-10 	      43	  30272876 ns/op	 2001917 B/op	   32483 allocs/op
PASS
ok  	github.com/ankur-anand/unisondb/internal/benchtests/broadcast/bench/ctxtimeout	19.154s
```