### PR TITLE
feat(relayer): Add Configurable Rate Limiting for WAL Replication

### DIFF
--- a/cmd/unisondb/config/config.go
+++ b/cmd/unisondb/config/config.go
@@ -81,6 +81,15 @@ type PProfConfig struct {
 	Port    int  `toml:"port"`
 }
 
+// WalIOGlobalLimiter defines global rate-limiting settings for controlling
+// WAL (Write-Ahead Log) write throughput across all namespaces during streaming replication,
+// in a short period, helping control resource usage (CPU, memory) at the current VM.
+type WalIOGlobalLimiter struct {
+	Enable    bool `toml:"enable"`
+	Burst     int  `toml:"burst"`
+	RateLimit int  `toml:"rate_limit"`
+}
+
 func ParseLevelPercents(cfg LogConfig) (map[slog.Level]float64, error) {
 	out := map[slog.Level]float64{
 		slog.LevelDebug: 100.0,

--- a/cmd/unisondb/config/config.go
+++ b/cmd/unisondb/config/config.go
@@ -18,15 +18,16 @@ import (
 
 // Config : top-level configuration.
 type Config struct {
-	HTTPPort     int                    `toml:"http_port"`
-	ListenIP     string                 `toml:"listen_ip"`
-	Grpc         GrpcConfig             `toml:"grpc_config"`
-	Storage      StorageConfig          `toml:"storage_config"`
-	PProfConfig  PProfConfig            `toml:"pprof_config"`
-	RelayConfigs map[string]RelayConfig `toml:"relayer_config"`
-	LogConfig    LogConfig              `toml:"log_config"`
-	Limiter      Limiter                `toml:"limiter"`
-	FuzzConfig   FuzzConfig             `toml:"fuzz_config"`
+	HTTPPort           int                    `toml:"http_port"`
+	ListenIP           string                 `toml:"listen_ip"`
+	Grpc               GrpcConfig             `toml:"grpc_config"`
+	Storage            StorageConfig          `toml:"storage_config"`
+	PProfConfig        PProfConfig            `toml:"pprof_config"`
+	RelayConfigs       map[string]RelayConfig `toml:"relayer_config"`
+	WalIOGlobalLimiter WalIOGlobalLimiter     `toml:"wal_io_global_limiter"`
+	LogConfig          LogConfig              `toml:"log_config"`
+	Limiter            Limiter                `toml:"limiter"`
+	FuzzConfig         FuzzConfig             `toml:"fuzz_config"`
 }
 
 type GrpcConfig struct {

--- a/internal/services/relayer/relayer.go
+++ b/internal/services/relayer/relayer.go
@@ -87,11 +87,11 @@ type RateLimitedWalIO struct {
 }
 
 // NewRateLimitedWalIO constructs a RateLimitedWalIO.
-func NewRateLimitedWalIO(ctx context.Context, w WalIO, ratePerSecond int, burstSize int) *RateLimitedWalIO {
+func NewRateLimitedWalIO(ctx context.Context, w WalIO, limiter *rate.Limiter) *RateLimitedWalIO {
 	return &RateLimitedWalIO{
 		ctx:        ctx,
 		underlying: w,
-		limiter:    rate.NewLimiter(rate.Limit(ratePerSecond), burstSize),
+		limiter:    limiter,
 	}
 }
 
@@ -164,6 +164,11 @@ func NewRelayer(engine *dbkernel.Engine,
 		startOffset:         currentOffset,
 		walIOHandler:        walHandler,
 	}
+}
+
+// CurrentWalIO returns the currently configured WalIO implementation for the Relayer.
+func (r *Relayer) CurrentWalIO() WalIO {
+	return r.walIOHandler
 }
 
 // EnableRateLimitedWalIO configures the Relayer to apply a token bucket rate limiter

--- a/internal/services/relayer/relayer.go
+++ b/internal/services/relayer/relayer.go
@@ -167,6 +167,8 @@ func NewRelayer(engine *dbkernel.Engine,
 }
 
 // CurrentWalIO returns the currently configured WalIO implementation for the Relayer.
+//
+//nolint:ireturn
 func (r *Relayer) CurrentWalIO() WalIO {
 	return r.walIOHandler
 }

--- a/internal/services/relayer/relayer.go
+++ b/internal/services/relayer/relayer.go
@@ -13,13 +13,15 @@ import (
 	v1 "github.com/ankur-anand/unisondb/schemas/proto/gen/go/unisondb/streamer/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
 )
 
-type Streamer interface {
-	GetLatestOffset(ctx context.Context) (*dbkernel.Offset, error)
-	StreamWAL(ctx context.Context) error
-}
+var (
+	ErrSegmentLagThresholdExceeded = errors.New("segment lag threshold exceeded")
+	// TODO: Refactor this to return the name should be coming from the Streamer Interface itself.
+	defaultStreamerLabel = "grpc"
+)
 
 var (
 	segmentLagGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
@@ -35,7 +37,38 @@ var (
 		Name:      "wal_segment_lag_threshold",
 		Help:      "Configured segment lag threshold for the WAL relayer per namespace",
 	}, []string{"namespace"})
+	rateLimiterWaitDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "rate_limiter_wait_duration_seconds",
+		Help:      "Time spent waiting for rate limiter tokens.",
+		Buckets:   prometheus.DefBuckets,
+	}, []string{"streamer"})
+
+	rateLimiterErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "rate_limiter_errors_total",
+		Help:      "Total number of rate limiter errors.",
+	}, []string{"streamer"})
+
+	rateLimiterSuccess = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Subsystem: promSubsystem,
+		Name:      "rate_limiter_success_total",
+		Help:      "Total number of successful rate limiter grants.",
+	}, []string{"streamer"})
 )
+
+type Streamer interface {
+	GetLatestOffset(ctx context.Context) (*dbkernel.Offset, error)
+	StreamWAL(ctx context.Context) error
+}
+
+// WalIO defines the interface for writing Write-Ahead Log (WAL) records.
+type WalIO interface {
+	Write(data *v1.WALRecord) error
+}
 
 type walIOHandler struct {
 	replica *dbkernel.ReplicaWALHandler
@@ -45,14 +78,43 @@ func (w walIOHandler) Write(data *v1.WALRecord) error {
 	return w.replica.ApplyRecord(data.Record, data.Offset)
 }
 
-var (
-	ErrSegmentLagThresholdExceeded = errors.New("segment lag threshold exceeded")
-)
+// RateLimitedWalIO wraps WalIO with a token bucket rate limiter.
+type RateLimitedWalIO struct {
+	// this should be the parent ctx that controls the entire program flow.
+	ctx        context.Context
+	underlying WalIO
+	limiter    *rate.Limiter
+}
+
+// NewRateLimitedWalIO constructs a RateLimitedWalIO.
+func NewRateLimitedWalIO(ctx context.Context, w WalIO, ratePerSecond int, burstSize int) *RateLimitedWalIO {
+	return &RateLimitedWalIO{
+		ctx:        ctx,
+		underlying: w,
+		limiter:    rate.NewLimiter(rate.Limit(ratePerSecond), burstSize),
+	}
+}
+
+// Write applies rate limiting before delegating to the underlying WalIO.
+func (r *RateLimitedWalIO) Write(data *v1.WALRecord) error {
+	start := time.Now()
+	err := r.limiter.Wait(r.ctx)
+	duration := time.Since(start)
+	rateLimiterWaitDuration.WithLabelValues(defaultStreamerLabel).Observe(duration.Seconds())
+	if err != nil {
+		rateLimiterErrors.WithLabelValues(defaultStreamerLabel).Inc()
+		return fmt.Errorf("rate limit exceeded: %w", err)
+	}
+	rateLimiterSuccess.WithLabelValues(defaultStreamerLabel).Inc()
+
+	return r.underlying.Write(data)
+}
 
 // Relayer relays WAL record from the upstream over the provided grpc connection for the given namespace.
 type Relayer struct {
-	namespace           string
-	engine              *dbkernel.Engine
+	namespace string
+	engine    *dbkernel.Engine
+	// TODO: refactor, relayer should be independent of this?
 	grpcConn            *grpc.ClientConn
 	client              Streamer
 	segmentLagThreshold int
@@ -62,7 +124,7 @@ type Relayer struct {
 	logger         *slog.Logger
 	startSegmentID int
 	startOffset    *dbkernel.Offset
-	walIOHandler   walIOHandler
+	walIOHandler   WalIO
 
 	offsetMonitorInterval time.Duration
 }
@@ -102,6 +164,30 @@ func NewRelayer(engine *dbkernel.Engine,
 		startOffset:         currentOffset,
 		walIOHandler:        walHandler,
 	}
+}
+
+// EnableRateLimitedWalIO configures the Relayer to apply a token bucket rate limiter
+// on WAL writes. This helps control replication throughput and prevents excessive
+// memory or CPU usage by slowing down WAL processing at the consumer side.
+// Must be called before calling the StartRelay else will panic.
+func (r *Relayer) EnableRateLimitedWalIO(rateLimit int, burstSize int) {
+	if r.started.Load() {
+		panic("cannot enable rate limiter after relay has started for namespace: " + r.namespace)
+	}
+	rlWalIO := NewRateLimitedWalIO(context.Background(), r.walIOHandler, rateLimit, burstSize)
+	r.walIOHandler = rlWalIO
+
+	var currOffset []byte
+	if r.startOffset != nil {
+		currOffset = r.startOffset.Encode()
+	}
+	r.client = streamer.NewGrpcStreamerClient(r.grpcConn, r.namespace, rlWalIO, currOffset)
+	r.logger.Info("[unisondb.relayer]",
+		slog.String("event_type", "relayer.rate_limiter.enabled"),
+		slog.String("namespace", r.namespace),
+		slog.Int("rate_limit", rateLimit),
+		slog.Int("burst_size", burstSize),
+	)
 }
 
 // StartRelay starts the WAL replication Sync with the upstream over the provided grpc-connection,

--- a/internal/services/relayer/relayer_test.go
+++ b/internal/services/relayer/relayer_test.go
@@ -251,16 +251,23 @@ func TestRelayer_WithRateLimiterWalWriter(t *testing.T) {
 
 	assert.False(t, isRateLimited, "should be simple")
 
+	rel.EnableRateLimitedWalIO(nil)
+	_, isRateLimited = rel.walIOHandler.(*RateLimitedWalIO)
+
+	assert.False(t, isRateLimited, "should be simple")
+
 	rateLimit := 5
 	burstSize := 2
 
-	rel.EnableRateLimitedWalIO(rateLimit, burstSize)
+	rateLimiterIO := NewRateLimitedWalIO(t.Context(), rel.walIOHandler, rateLimit, burstSize)
+
+	rel.EnableRateLimitedWalIO(rateLimiterIO)
 
 	_, isRateLimited = rel.walIOHandler.(*RateLimitedWalIO)
 	assert.True(t, isRateLimited, "should be of type RateLimitedWalIO after EnableRateLimitedWalIO")
 	// before the start it should be allowed to change
 	rel.startOffset = &dbkernel.Offset{SegmentID: 10, Offset: 100}
-	rel.EnableRateLimitedWalIO(rateLimit, burstSize)
+	rel.EnableRateLimitedWalIO(rateLimiterIO)
 	_, isRateLimited = rel.walIOHandler.(*RateLimitedWalIO)
 	assert.True(t, isRateLimited, "should be of type RateLimitedWalIO after EnableRateLimitedWalIO")
 
@@ -271,6 +278,6 @@ func TestRelayer_WithRateLimiterWalWriter(t *testing.T) {
 		}
 	}()
 
-	rel.EnableRateLimitedWalIO(10, 5)
+	rel.EnableRateLimitedWalIO(rateLimiterIO)
 
 }

--- a/internal/services/relayer/relayer_test.go
+++ b/internal/services/relayer/relayer_test.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"log/slog"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -60,7 +62,7 @@ type mockStreamer struct {
 	injectErr    error
 	mockedOffset *dbkernel.Offset
 	engine       *dbkernel.Engine
-	walIOHandler walIOHandler
+	walIOHandler WalIO
 }
 
 func (m *mockStreamer) GetLatestOffset(ctx context.Context) (*dbkernel.Offset, error) {
@@ -183,4 +185,92 @@ func TestRelayer_StartRelay(t *testing.T) {
 	assert.NoError(t, err)
 	logStr := logBuf.String()
 	assert.Contains(t, logStr, "relayer.relay.started")
+}
+
+type mockWalIO struct {
+	writeCount atomic.Int64
+}
+
+func (m *mockWalIO) Write(data *v1.WALRecord) error {
+	m.writeCount.Add(1)
+	return nil
+}
+
+func TestRateLimitedWalIO_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	mock := &mockWalIO{}
+	rlWalIO := NewRateLimitedWalIO(ctx, mock, 1, 1)
+
+	record := &v1.WALRecord{Offset: []byte("test-offset"), Record: []byte("test-record")}
+
+	err := rlWalIO.Write(record)
+	assert.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = rlWalIO.Write(record)
+		}()
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		cancel()
+	}
+
+	assert.LessOrEqual(t, mock.writeCount.Load(), int64(3), "should have blocked excessive writes")
+}
+
+func TestRelayer_WithRateLimiterWalWriter(t *testing.T) {
+	baseDir := t.TempDir()
+	namespace := "relayer"
+
+	engine, err := dbkernel.NewStorageEngine(baseDir, namespace, dbkernel.NewDefaultEngineConfig())
+	assert.NoError(t, err)
+
+	t.Cleanup(func() {
+		assert.NoError(t, engine.Close(context.Background()))
+	})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{}))
+
+	rel := NewRelayer(engine, namespace, nil, 10, logger)
+	_, isRateLimited := rel.walIOHandler.(*RateLimitedWalIO)
+
+	assert.False(t, isRateLimited, "should be simple")
+
+	rateLimit := 5
+	burstSize := 2
+
+	rel.EnableRateLimitedWalIO(rateLimit, burstSize)
+
+	_, isRateLimited = rel.walIOHandler.(*RateLimitedWalIO)
+	assert.True(t, isRateLimited, "should be of type RateLimitedWalIO after EnableRateLimitedWalIO")
+	// before the start it should be allowed to change
+	rel.startOffset = &dbkernel.Offset{SegmentID: 10, Offset: 100}
+	rel.EnableRateLimitedWalIO(rateLimit, burstSize)
+	_, isRateLimited = rel.walIOHandler.(*RateLimitedWalIO)
+	assert.True(t, isRateLimited, "should be of type RateLimitedWalIO after EnableRateLimitedWalIO")
+
+	rel.started.Store(true)
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("Expected panic when EnableRateLimitedWalIO is called after StartRelay, but it did not panic")
+		}
+	}()
+
+	rel.EnableRateLimitedWalIO(10, 5)
+
 }


### PR DESCRIPTION
This PR introduces a token-bucket based rate limiter for controlling WAL (Write-Ahead Log) replication throughput on the relayer client. This helps prevent excessive memory/CPU usage during replication and mitigates the risk of backpressure on resource-constrained environments.