### PR TITLE
feat: Switch to Castagnoli Polynomial for Faster CRC32 Computation

### DIFF
--- a/pkg/walfs/segment.go
+++ b/pkg/walfs/segment.go
@@ -36,6 +36,8 @@ const (
 	segmentHeaderVersion = 1
 )
 
+var crcTable = crc32.MakeTable(crc32.Castagnoli)
+
 // SegmentHeader encodes all the necessary information about the segment file at the top of the file.
 // Its Size is 64 byte once encoded.
 type SegmentHeader struct {
@@ -724,8 +726,8 @@ func (r *SegmentReader) LastRecordPosition() *RecordPosition {
 }
 
 func crc32Checksum(header []byte, data []byte) uint32 {
-	sum := crc32.ChecksumIEEE(header)
-	return crc32.Update(sum, crc32.IEEETable, data)
+	sum := crc32.Checksum(header, crcTable)
+	return crc32.Update(sum, crcTable, data)
 }
 
 // SegmentFileName returns the file name of a Segment file.


### PR DESCRIPTION
replaces the default IEEE polynomial with the Castagnoli polynomial (crc32.Castagnoli) for CRC32 checksum calculations.

Running this on fuzzer with 1000 local relayer and pprof.

## Before
```
4.72s  3.83% 92.87%      4.72s  3.83%  hash/crc32.ieeeUpdate
```

## After
```
 2.67s  2.14% 90.29%      2.67s  2.14%  hash/crc32.ieeeUpdate
```

This comes roughly as 43.33% faster in our WAL.