### PR TITLE
optimize: skip CRC validation for reads from active (unsealed) WAL segments

### DIFF
--- a/pkg/walfs/segment_test.go
+++ b/pkg/walfs/segment_test.go
@@ -166,6 +166,23 @@ func TestSegment_InvalidCRC(t *testing.T) {
 
 	seg.mmapData[pos.Offset] ^= 0xFF
 	_, _, err = seg.Read(pos.Offset)
+	assert.NoError(t, err)
+	seg.isSealed.Store(true)
+	_, _, err = seg.Read(pos.Offset)
+	assert.ErrorIs(t, err, ErrInvalidCRC)
+	seg.isSealed.Store(false)
+	_, _, err = seg.Read(pos.Offset)
+	assert.NoError(t, err)
+	err = seg.SealSegment()
+	assert.NoError(t, err)
+	_, _, err = seg.Read(pos.Offset)
+	assert.ErrorIs(t, err, ErrInvalidCRC)
+
+	assert.NoError(t, seg.Close())
+
+	seg, err = OpenSegmentFile(tmpDir, ".wal", 1)
+	assert.NoError(t, err)
+	_, _, err = seg.Read(pos.Offset)
 	assert.ErrorIs(t, err, ErrInvalidCRC)
 }
 

--- a/pkg/walfs/walog.go
+++ b/pkg/walfs/walog.go
@@ -499,7 +499,6 @@ func (wl *WALog) QueuedSegmentsForDeletion() map[SegmentID]*Segment {
 // CleanupStalePendingSegments scans pendingDeletion and segments maps.
 // If a segment's file no longer exists on disk, it removes those entries from both maps.
 func (wl *WALog) CleanupStalePendingSegments() {
-
 	toRemove := make(map[SegmentID]*Segment)
 
 	wl.deletionMu.Lock()


### PR DESCRIPTION
This change optimizes the WAL Segment.Read() path by skipping CRC32 validation for unsealed (active) segments.

CRC validation ensures data durability after a crash, but:
	•	Active segments are still in-memory and actively written to.
	•	CRC mismatches are extremely unlikely unless memory is corrupted.

While this benchmark is non-statistical run, still the improvement is huge for active segment reader.

```
benchstat old.txt new.txt | grep Read
Segment/NoSync/Sequential/Read/Tiny_16B-10                           24.64n ± ∞ ¹    15.65n ± ∞ ¹        ~ (p=1.000 n=1) ²
Segment/NoSync/Sequential/SequentialRead/Tiny_16B-10                 4.522µ ± ∞ ¹    3.061µ ± ∞ ¹        ~ (p=1.000 n=1) ²
Segment/NoSync/Sequential/Read/Small_1KB-10                         131.30n ± ∞ ¹    15.91n ± ∞ ¹        ~ (p=1.000 n=1) ²
Segment/NoSync/Sequential/SequentialRead/Small_1KB-10               14.802µ ± ∞ ¹    3.129µ ± ∞ ¹        ~ (p=1.000 n=1) ²
Segment/NoSync/Sequential/Read/Medium_32KB-10                      4007.00n ± ∞ ¹    15.54n ± ∞ ¹        ~ (p=1.000 n=1) ²
Segment/NoSync/Sequential/SequentialRead/Medium_32KB-10            411.024µ ± ∞ ¹    3.152µ ± ∞ ¹        ~ (p=1.000 n=1) ²
Segment/NoSync/Sequential/Read/Large_64KB-10                       7714.00n ± ∞ ¹    15.70n ± ∞ ¹        ~ (p=1.000 n=1) ²
Segment/NoSync/Sequential/SequentialRead/Large_64KB-10             777.292µ ± ∞ ¹    3.190µ ± ∞ ¹        ~ (p=1.000 n=1) ²
Segment/NoSync/Sequential/Read/Large_512KB-10                     62100.00n ± ∞ ¹    16.00n ± ∞ ¹        ~ (p=1.000 n=1) ²
Segment/NoSync/Sequential/SequentialRead/Large_512KB-10           1927.222µ ± ∞ ¹    1.213µ ± ∞ ¹        ~ (p=1.000 n=1) ²
Segment/NoSync/Random/Read/Tiny_16B-10                               24.62n ± ∞ ¹    15.65n ± ∞ ¹        ~ (p=1.000 n=1) ²
Segment/NoSync/Random/SequentialRead/Tiny_16B-10                     3.986µ ± ∞ ¹    3.111µ ± ∞ ¹        ~ (p=1.000 n=1) ²
Segment/NoSync/Random/Read/Small_1KB-10                             130.20n ± ∞ ¹    15.63n ± ∞ ¹        ~ (p=1.000 n=1) ²
Segment/NoSync/Random/SequentialRead/Small_1KB-10                   14.662µ ± ∞ ¹    3.093µ ± ∞ ¹        ~ (p=1.000 n=1) ²
Segment/NoSync/Random/Read/Medium_32KB-10                          3817.00n ± ∞ ¹    15.82n ± ∞ ¹        ~ (p=1.000 n=1) ²
Segment/NoSync/Random/SequentialRead/Medium_32KB-10                381.530µ ± ∞ ¹    3.213µ ± ∞ ¹        ~ (p=1.000 n=1) ²
Segment/NoSync/Random/Read/Large_64KB-10                           7710.00n ± ∞ ¹    15.80n ± ∞ ¹        ~ (p=1.000 n=1) ²
Segment/NoSync/Random/SequentialRead/Large_64KB-10                 778.734µ ± ∞ ¹    3.208µ ± ∞ ¹        ~ (p=1.000 n=1) ²
Segment/NoSync/Random/Read/Large_512KB-10                         61299.00n ± ∞ ¹    16.14n ± ∞ ¹        ~ (p=1.000 n=1) ²
Segment/NoSync/Random/SequentialRead/Large_512KB-10               1918.441µ ± ∞ ¹    1.211µ ± ∞ ¹        ~ (p=1.000 n=1) ²
```