### PR TITLE
fix: don't recaculate the checksum in replicator.

### DIFF
--- a/internal/services/relayer/local.go
+++ b/internal/services/relayer/local.go
@@ -55,9 +55,9 @@ func NewLocalWalRelayer(id int) *LocalWalRelayer {
 func (n *LocalWalRelayer) Run(ctx context.Context, engine *dbkernel.Engine, metricsTickInterval time.Duration) error {
 	rpInstance := replicator.NewReplicator(engine,
 		20,
-		100*time.Millisecond, n.lastOffset, "local")
+		1*time.Second, n.lastOffset, "local")
 
-	walReceiver := make(chan []*v1.WALRecord, 2)
+	walReceiver := make(chan []*v1.WALRecord, 100)
 	replicatorErrors := make(chan error, 2)
 	go func() {
 		err := rpInstance.Replicate(ctx, walReceiver)

--- a/pkg/replicator/replicator.go
+++ b/pkg/replicator/replicator.go
@@ -3,7 +3,6 @@ package replicator
 import (
 	"context"
 	"errors"
-	"hash/crc32"
 	"io"
 	"time"
 
@@ -144,9 +143,10 @@ func (r *Replicator) replicateFromReader(ctx context.Context, recordsChan chan<-
 		}
 
 		walRecord := &v1.WALRecord{
-			Offset:        pos.Encode(),
-			Record:        value,
-			Crc32Checksum: crc32.ChecksumIEEE(value),
+			Offset: pos.Encode(),
+			Record: value,
+			// TODO: Get From the WAL Reader itself. Don't calculate here.
+			//Crc32Checksum: crc32.Checksum(value, crcTable),
 		}
 
 		batch = append(batch, walRecord)


### PR DESCRIPTION
TODO: get checksum from the WAL reader itself.