### PR TITLE
perf: Add TailReader and remove ctx.Done from hot path for low-latency replication

### DIFF
--- a/dbkernel/common.go
+++ b/dbkernel/common.go
@@ -25,6 +25,7 @@ var (
 	ErrDatabaseDirInUse = errors.New("pid.lock is held by another process")
 	ErrInternalError    = errors.New("internal error")
 	ErrMisMatchKeyType  = errors.New("mismatch key type with existing value")
+	ErrNoNewData        = wal.ErrNoNewData
 )
 
 var (

--- a/dbkernel/engine_public.go
+++ b/dbkernel/engine_public.go
@@ -534,3 +534,14 @@ func (e *Engine) NewReaderWithStart(startPos *Offset) (r *Reader, err error) {
 
 	return e.walIO.NewReaderWithStart(startPos)
 }
+
+// NewReaderWithTail returns a reader that starts from the provided offset,
+// and supports tail-following behavior.
+// It returns ErrNoNewData when no new entries are available *yet*,
+// instead of io.EOF.
+func (e *Engine) NewReaderWithTail(startPos *Offset) (*Reader, error) {
+	if startPos == nil {
+		return e.walIO.NewReader(wal.WithActiveTail(true))
+	}
+	return e.walIO.NewReaderWithStart(startPos, wal.WithActiveTail(true))
+}

--- a/dbkernel/internal/wal/common.go
+++ b/dbkernel/internal/wal/common.go
@@ -74,6 +74,7 @@ const (
 var (
 	ErrWalNextOffset = errors.New("wal next offset out of range")
 	ErrWalFSync      = walfs.ErrFsync
+	ErrNoNewData     = walfs.ErrNoNewData
 )
 
 // Config stores all tunable parameters for WAL.

--- a/dbkernel/internal/wal/wal.go
+++ b/dbkernel/internal/wal/wal.go
@@ -195,7 +195,6 @@ func (r *Reader) Next() ([]byte, *Offset, error) {
 		return nil, nil, err
 
 	case err != nil:
-		r.taggedScope.Counter(metricsWalReadTotal).Inc(1)
 		r.taggedScope.Counter(metricsWalReadErrorTotal).Inc(1)
 		return nil, nil, err
 	}
@@ -205,8 +204,6 @@ func (r *Reader) Next() ([]byte, *Offset, error) {
 	if rand.Float64() < 0.05 || dur > 10*time.Millisecond {
 		r.taggedScope.Histogram(metricsWalReadDuration, readLatencyBuckets).RecordDuration(dur)
 	}
-	r.taggedScope.Counter(metricsWalReadTotal).Inc(1)
-
 	return data, pos, nil
 }
 
@@ -227,6 +224,7 @@ func (w *WalIO) NewReader(options ...ReaderOption) (*Reader, error) {
 	for _, opt := range options {
 		opt(reader)
 	}
+
 	return reader, nil
 }
 

--- a/dbkernel/internal/wal/wal.go
+++ b/dbkernel/internal/wal/wal.go
@@ -155,11 +155,20 @@ func (w *WalIO) Append(data []byte) (*Offset, error) {
 	return &off, err
 }
 
+type ReaderOption func(*Reader)
+
+func WithActiveTail(enabled bool) ReaderOption {
+	return func(r *Reader) {
+		r.withActiveTail = enabled
+	}
+}
+
 type Reader struct {
-	appendReader *walfs.Reader
-	closed       atomic.Bool
-	namespace    string
-	taggedScope  umetrics.Scope
+	appendReader   *walfs.Reader
+	closed         atomic.Bool
+	namespace      string
+	taggedScope    umetrics.Scope
+	withActiveTail bool
 }
 
 // Next returns the next chunk data and its position in the WAL.
@@ -169,24 +178,36 @@ func (r *Reader) Next() ([]byte, *Offset, error) {
 	if r.closed.Load() {
 		return nil, nil, io.EOF
 	}
-	startTime := time.Now()
-	value, off, err := r.appendReader.Next()
-	if err != nil && !errors.Is(err, io.EOF) {
+
+	start := time.Now()
+	data, pos, err := r.appendReader.Next()
+
+	switch {
+	case errors.Is(err, walfs.ErrNoNewData):
+		if !r.withActiveTail {
+			r.Close()
+			return nil, nil, io.EOF
+		}
+		return nil, nil, err
+
+	case errors.Is(err, io.EOF):
+		r.Close()
+		return nil, nil, err
+
+	case err != nil:
 		r.taggedScope.Counter(metricsWalReadTotal).Inc(1)
 		r.taggedScope.Counter(metricsWalReadErrorTotal).Inc(1)
+		return nil, nil, err
 	}
-	if errors.Is(err, io.EOF) {
-		r.Close()
+
+	// Successful read
+	dur := time.Since(start)
+	if rand.Float64() < 0.05 || dur > 10*time.Millisecond {
+		r.taggedScope.Histogram(metricsWalReadDuration, readLatencyBuckets).RecordDuration(dur)
 	}
-	if err == nil {
-		duration := time.Since(startTime)
-		// we are sampling only 5% of fast-path reads, but always capture slow reads
-		if rand.Float64() < 0.05 || duration > 10*time.Millisecond {
-			r.taggedScope.Histogram(metricsWalReadDuration, readLatencyBuckets).RecordDuration(duration)
-		}
-		r.taggedScope.Counter(metricsWalReadTotal).Inc(1)
-	}
-	return value, off, err
+	r.taggedScope.Counter(metricsWalReadTotal).Inc(1)
+
+	return data, pos, nil
 }
 
 func (r *Reader) Close() {
@@ -197,22 +218,33 @@ func (r *Reader) Close() {
 
 // NewReader returns a new instance of WIOReader, allowing the caller to
 // access WAL logs for replication, recovery, or log processing.
-func (w *WalIO) NewReader() (*Reader, error) {
-	return &Reader{
+func (w *WalIO) NewReader(options ...ReaderOption) (*Reader, error) {
+	reader := &Reader{
 		appendReader: w.appendLog.NewReader(),
 		namespace:    w.namespace,
 		taggedScope:  w.taggedScope,
-	}, nil
+	}
+	for _, opt := range options {
+		opt(reader)
+	}
+	return reader, nil
 }
 
 // NewReaderWithStart returns a new instance of WIOReader from the provided Offset.
-func (w *WalIO) NewReaderWithStart(offset *Offset) (*Reader, error) {
-	reader, err := w.appendLog.NewReaderWithStart(*offset)
-	return &Reader{
-		appendReader: reader,
+func (w *WalIO) NewReaderWithStart(offset *Offset, options ...ReaderOption) (*Reader, error) {
+	underlyingReader, err := w.appendLog.NewReaderWithStart(*offset)
+	if err != nil {
+		return nil, err
+	}
+	reader := &Reader{
+		appendReader: underlyingReader,
 		namespace:    w.namespace,
 		taggedScope:  w.taggedScope,
-	}, err
+	}
+	for _, opt := range options {
+		opt(reader)
+	}
+	return reader, nil
 }
 
 // GetTransactionRecords returns all the WalRecord that is part of the particular Txn.

--- a/internal/services/streamer/grpc_streamer.go
+++ b/internal/services/streamer/grpc_streamer.go
@@ -125,6 +125,11 @@ func (s *GrpcStreamer) StreamWalRecords(request *v1.StreamWalRecordsRequest, g g
 		batchSize,
 		batchWaitTime, meta, "grpc")
 
+	currentOffset := engine.CurrentOffset()
+	if meta != nil && currentOffset == nil {
+		return services.ToGRPCError(namespace, reqID, method, services.ErrInvalidMetadata)
+	}
+
 	// when server is closed, the goroutine would be closed upon
 	// cancel of ctx.
 	// walReceiver should be closed only when Replicate method returns.

--- a/pkg/walfs/walog.go
+++ b/pkg/walfs/walog.go
@@ -441,6 +441,17 @@ func (wl *WALog) MarkSegmentsForDeletion() {
 
 	var candidates []*Segment
 	for _, seg := range clonedSegments {
+		if seg.closed.Load() {
+			// already closed
+			continue
+		}
+		if seg.markedForDeletion.Load() {
+			// already queued
+			continue
+		}
+		if len(seg.mmapData) < segmentHeaderSize {
+			continue
+		}
 		if IsSealed(seg.GetFlags()) {
 			candidates = append(candidates, seg)
 		}


### PR DESCRIPTION
- a series of performance-focused improvements to the WAL replication system.

Tail Replicator Path
	•	Replaces full Reader traversal with a dedicated tail-only reader (TailReader) to stream from the latest unsealed segment directly.

### select Ctx.Done in hot path is issue

```javascript
OUTINE ======================== github.com/ankur-anand/unisondb/pkg/replicator.(*Replicator).replicateFromReader.func1 in /Users/ankur/code/private/git@ankur-anand/unisondb/pkg/replicator/replicator.go
      20ms     53.83s (flat, cum) 26.81% of Total
      10ms       10ms    128:	sendFunc := func() {
         .          .    129:		if len(batch) > 0 {
         .      580ms    130:			mKeyReplicatorRecordsTotal.WithLabelValues(namespace, r.replicatorEngine).Add(float64(len(batch)))
      10ms      470ms    131:			mKeyReplicatorBatchesTotal.WithLabelValues(namespace, r.replicatorEngine).Add(1)
         .     52.74s    132:			select {
         .          .    133:			case recordsChan <- batch:
         .       10ms    134:				batch = []*v1.WALRecord{}
         .       20ms    135:			case <-ctx.Done():
         .          .    136:				if r.reader != nil {
         .          .    137:					r.reader.Close()
         .          .    138:				}
         .          .    139:				return
         .          .    140:			}
(pprof) %
```

###Pure Simple Channel

```javascript
ROUTINE ======================== github.com/ankur-anand/unisondb/pkg/replicator.(*Replicator).replicateFromReader.func1 in /Users/ankur/code/private/git@ankur-anand/unisondb/pkg/replicator/replicator.go
      30ms      1.70s (flat, cum)  0.92% of Total
         .          .    135:	sendFunc := func() {
      30ms       30ms    136:		if len(batch) > 0 {
         .          .    137:			batch = []*v1.WALRecord{}
         .      1.67s    138:			select {
         .          .    139:			case recordsChan <- batch:
         .          .    140:				batch = []*v1.WALRecord{}
         .          .    141:			case <-r.ctxDone:
         .          .    142:				if r.reader != nil {
         .          .    143:					r.reader.Close()
(pprof) list .replicateFromReader
Total: 184.09s
```

### WaitForAppend

```javascript
(pprof) list .WaitForAppend
Total: 184.09s
ROUTINE ======================== github.com/ankur-anand/unisondb/dbkernel.(*Engine).WaitForAppend in /Users/ankur/code/private/git@ankur-anand/unisondb/dbkernel/engine_public.go
      20ms     33.75s (flat, cum) 18.33% of Total
         .          .    206:func (e *Engine) WaitForAppendOrDone(callerDone chan struct{}, timeout time.Duration, lastSeen *Offset) error {
         .          .    207:	currentPos := e.currentOffset.Load()
         .          .    208:	if currentPos != nil && hasNewWriteSince(currentPos, lastSeen) {
         .          .    209:		return nil
         .          .    210:	}
         .          .    211:
         .      170ms    212:	e.notifierMu.RLock()
      10ms       10ms    213:	done := e.appendNotify
         .       10ms    214:	e.notifierMu.RUnlock()
         .          .    215:
         .          .    216:	// check again (ca)
         .          .    217:	currentPos = e.currentOffset.Load()
         .          .    218:	if currentPos != nil && hasNewWriteSince(currentPos, lastSeen) {
         .          .    219:		return nil
         .          .    220:	}
         .          .    221:
         .     33.36s    222:	select {
         .          .    223:	case <-callerDone:
         .          .    224:		return nil
         .          .    225:	case <-done:
         .          .    226:		return nil
      10ms      200ms    227:	case <-time.After(timeout):
         .          .    228:		return ErrWaitTimeoutExceeded
         .          .    229:	}
         .          .    230:}
         .          .    231:
         .          .    232:func hasNewWriteSince(current, lastSeen *Offset) bool {
(pprof)
```

```javascript
(pprof) list WaitForAppendOrDone
Total: 202.91s
ROUTINE ======================== github.com/ankur-anand/unisondb/dbkernel.(*Engine).WaitForAppendOrDone in /Users/ankur/code/private/git@ankur-anand/unisondb/dbkernel/engine_public.go
      20ms     10.77s (flat, cum)  5.31% of Total
         .          .    206:func (e *Engine) WaitForAppendOrDone(callerDone chan struct{}, timeout time.Duration, lastSeen *Offset) error {
         .          .    207:	currentPos := e.currentOffset.Load()
      10ms       10ms    208:	if currentPos != nil && hasNewWriteSince(currentPos, lastSeen) {
         .          .    209:		return nil
         .          .    210:	}
         .          .    211:
         .      330ms    212:	e.notifierMu.RLock()
      10ms       10ms    213:	done := e.appendNotify
         .          .    214:	e.notifierMu.RUnlock()
         .          .    215:
         .          .    216:	// check again (ca)
         .          .    217:	currentPos = e.currentOffset.Load()
         .          .    218:	if currentPos != nil && hasNewWriteSince(currentPos, lastSeen) {
         .          .    219:		return nil
         .          .    220:	}
         .          .    221:
         .      9.92s    222:	select {
         .          .    223:	case <-callerDone:
         .          .    224:		return nil
         .          .    225:	case <-done:
         .          .    226:		return nil
         .      500ms    227:	case <-time.After(timeout):
         .          .    228:		return ErrWaitTimeoutExceeded
         .          .    229:	}
         .          .    230:}
         .          .    231:
         .          .    232:func hasNewWriteSince(current, lastSeen *Offset) bool {
(pprof)
```