### PR TITLE
dbkernel: simplify WaitForAppend API to context-based cancelled

### DIFF
--- a/dbkernel/engine_public.go
+++ b/dbkernel/engine_public.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"sync"
 	"time"
 
 	"github.com/ankur-anand/unisondb/dbkernel/internal"
@@ -229,35 +228,6 @@ func (e *Engine) BatchDeleteKV(keys [][]byte) error {
 	defer timer.Stop()
 
 	return e.persistKeyValue(keys, nil, logrecord.LogOperationTypeDelete)
-}
-
-var timerPool = sync.Pool{
-	New: func() any {
-		t := time.NewTimer(time.Hour)
-		if !t.Stop() {
-			select {
-			case <-t.C:
-			default:
-			}
-		}
-		return t
-	},
-}
-
-func getTimer(d time.Duration) *time.Timer {
-	t := timerPool.Get().(*time.Timer)
-	t.Reset(d)
-	return t
-}
-
-func putTimer(t *time.Timer) {
-	if !t.Stop() {
-		select {
-		case <-t.C:
-		default:
-		}
-	}
-	timerPool.Put(t)
 }
 
 // WaitForAppendOrDone blocks until a put/delete operation occurs or context cancelled is done.

--- a/dbkernel/engine_public_test.go
+++ b/dbkernel/engine_public_test.go
@@ -178,7 +178,7 @@ func TestEngine_WaitForAppend(t *testing.T) {
 	value := []byte("test-value")
 
 	callerDone := make(chan struct{})
-	
+
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {

--- a/pkg/replicator/replicator.go
+++ b/pkg/replicator/replicator.go
@@ -13,10 +13,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-const (
-	waitForAppendDefaultTimeout = 30 * time.Second
-)
-
 var (
 	mKeyActiveReplicator = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "unisondb",
@@ -102,7 +98,7 @@ func (r *Replicator) Replicate(ctx context.Context, recordsChan chan<- []*v1.WAL
 			return ctx.Err()
 		}
 
-		err := r.engine.WaitForAppendOrDone(r.ctxDone, waitForAppendDefaultTimeout, &r.lastOffset)
+		err := r.engine.WaitForAppendOrDone(r.ctxDone, &r.lastOffset)
 
 		if err != nil && !errors.Is(err, dbkernel.ErrWaitTimeoutExceeded) {
 			if r.reader != nil {


### PR DESCRIPTION
dbkernel: simplify WaitForAppend API to context-based cancellation

CPU Implication:

```
         .     16.08s    105:		err := r.engine.WaitForAppendOrDone(r.ctxDone, waitForAppendDefaultTimeout, &r.lastOffset)
```

New

````
        .      5.93s    105:		err := r.engine.WaitForAppendOrDone(r.ctxDone, waitForAppendDefaultTimeout, &r.lastOffset)
````

Memory implications also hugely seen.

