### PR TITLE
fix: optimistic txn conflict trackin

### DIFF
--- a/dbkernel/engine.go
+++ b/dbkernel/engine.go
@@ -7,6 +7,7 @@ import (
 	"hash/crc32"
 	"log"
 	"log/slog"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,7 +30,8 @@ import (
 )
 
 const (
-	minArenaSize = 1024 * 200
+	minArenaSize            = 1024 * 200
+	keyVersionEvictInterval = time.Minute
 )
 
 var (
@@ -122,6 +124,8 @@ type Engine struct {
 	opsFlushedCounter atomic.Uint64
 	currentOffset     atomic.Pointer[wal.Offset]
 	namespace         string
+	keyVersions       map[string]uint64
+	activeTxnBegins   map[uint64]int
 	dataStore         internal.BTreeStore
 	walIO             *wal.WalIO
 	walSyncer         walSyncer
@@ -198,6 +202,8 @@ func NewStorageEngine(dataDir, namespace string, conf *EngineConfig) (*Engine, e
 		taggedScope:               taggedScope,
 		changeNotifier:            chNotifier,
 		coalesceDuration:          conf.WriteNotifyCoalescing.Duration,
+		keyVersions:               make(map[string]uint64),
+		activeTxnBegins:           make(map[uint64]int),
 	}
 	engine.backupRoot = filepath.Join(dataDir, BackupRootDirName)
 	engine.backupNamespaceRoot = filepath.Join(engine.backupRoot, namespace)
@@ -213,6 +219,7 @@ func NewStorageEngine(dataDir, namespace string, conf *EngineConfig) (*Engine, e
 	engine.asyncMemTableFlusher(ctx)
 	engine.syncWalAtInterval(ctx)
 	engine.fsyncBtreeAtInterval(ctx)
+	engine.startKeyVersionEvicter(ctx)
 
 	if err := engine.loadMetaValues(); err != nil {
 		return nil, err
@@ -479,6 +486,7 @@ func (e *Engine) persistKeyValue(keys [][]byte, values [][]byte, op logrecord.Lo
 		}
 	}
 
+	e.recordKeyVersions(keys, index)
 	e.writeOffset(offset)
 	return nil
 }
@@ -539,6 +547,7 @@ func (e *Engine) persistRowColumnAction(op logrecord.LogOperationType, rowKeys [
 		}
 	}
 
+	e.recordKeyVersions(rowKeys, index)
 	e.writeOffset(offset)
 	return nil
 }
@@ -616,6 +625,98 @@ func decodeOperation(v y.ValueStruct) logrecord.LogOperationType {
 
 func decodeEntryType(v y.ValueStruct) logrecord.LogEntryType {
 	return logrecord.LogEntryType(v.UserMeta)
+}
+
+// recordKeyVersions updates the latest committed LSN for the provided keys.
+func (e *Engine) recordKeyVersions(keys [][]byte, lsn uint64) {
+	if e.keyVersions == nil {
+		e.keyVersions = make(map[string]uint64)
+	}
+	for _, key := range keys {
+		e.keyVersions[string(key)] = lsn
+	}
+}
+
+// checkKeyConflicts returns an error if any of the provided keys have a committed
+// LSN greater than the provided startLSN.
+func (e *Engine) checkKeyConflicts(keys [][]byte, startLSN uint64) error {
+	for _, key := range keys {
+		if lsn, ok := e.keyVersions[string(key)]; ok && lsn > startLSN {
+			return ErrTxnConflict
+		}
+	}
+	return nil
+}
+
+// registerTxnBegin tracks the begin LSN for an active transaction.
+func (e *Engine) registerTxnBegin(lsn uint64) {
+	e.activeTxnBegins[lsn]++
+}
+
+// unregisterTxnBegin removes the begin LSN for an active transaction.
+func (e *Engine) unregisterTxnBegin(lsn uint64) {
+	if count, ok := e.activeTxnBegins[lsn]; ok {
+		if count <= 1 {
+			delete(e.activeTxnBegins, lsn)
+			return
+		}
+		e.activeTxnBegins[lsn] = count - 1
+	}
+}
+
+// minActiveTxnBegin returns the smallest begin LSN across active txns.
+// If there are no active txns, MaxUint64 is returned.
+func (e *Engine) minActiveTxnBegin() uint64 {
+	if len(e.activeTxnBegins) == 0 {
+		return math.MaxUint64
+	}
+	min := uint64(math.MaxUint64)
+	for lsn := range e.activeTxnBegins {
+		if lsn < min {
+			min = lsn
+		}
+	}
+	return min
+}
+
+// evictKeyVersions removes version entries that are older than the oldest active txn.
+func (e *Engine) evictKeyVersions() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if len(e.keyVersions) == 0 {
+		return
+	}
+
+	minBegin := e.minActiveTxnBegin()
+	if minBegin == math.MaxUint64 {
+		// no active txns, clear all to keep the map bounded.
+		e.keyVersions = make(map[string]uint64)
+		return
+	}
+
+	for key, version := range e.keyVersions {
+		if version <= minBegin {
+			delete(e.keyVersions, key)
+		}
+	}
+}
+
+func (e *Engine) startKeyVersionEvicter(ctx context.Context) {
+	e.wg.Add(1)
+	go func() {
+		defer e.wg.Done()
+		ticker := time.NewTicker(keyVersionEvictInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				e.evictKeyVersions()
+			}
+		}
+	}()
 }
 
 // used for testing purposes.

--- a/dbkernel/engine_test.go
+++ b/dbkernel/engine_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"sync"
@@ -1312,4 +1313,160 @@ func readWalRecordLSN(t *testing.T, walog *walfs.WALog, idx uint64) uint64 {
 	fbRecord := logrecord.GetRootAsLogRecord(copyData, 0)
 	decoded := logcodec.DeserializeFBRootLogRecord(fbRecord)
 	return decoded.LSN
+}
+
+func TestKeyVersionEvictionRespectsActiveTxns(t *testing.T) {
+	baseDir := t.TempDir()
+	engine, err := NewStorageEngine(baseDir, "eviction_ns", NewDefaultEngineConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = engine.Close(context.Background())
+	})
+
+	require.NoError(t, engine.PutKV([]byte("k1"), []byte("v1")))
+	engine.mu.RLock()
+	require.Equal(t, 1, len(engine.keyVersions))
+	engine.mu.RUnlock()
+
+	engine.evictKeyVersions()
+	engine.mu.RLock()
+	require.Equal(t, 0, len(engine.keyVersions))
+	engine.mu.RUnlock()
+
+	txn, err := engine.NewTxn(logrecord.LogOperationTypeInsert, logrecord.LogEntryTypeKV)
+	require.NoError(t, err)
+	require.NoError(t, txn.AppendKVTxn([]byte("k2"), []byte("v2")))
+	require.NoError(t, engine.PutKV([]byte("k3"), []byte("v3")))
+
+	engine.evictKeyVersions()
+	engine.mu.RLock()
+	preserved := len(engine.keyVersions)
+	engine.mu.RUnlock()
+	require.NotEqual(t, 0, preserved, "versions should stay while txn is active")
+
+	require.NoError(t, txn.Commit())
+	engine.evictKeyVersions()
+	engine.mu.RLock()
+	defer engine.mu.RUnlock()
+	require.Equal(t, 0, len(engine.keyVersions))
+}
+
+func TestEvictKeyVersionsRespectsOldestTxn(t *testing.T) {
+	e := &Engine{
+		keyVersions:     map[string]uint64{"a": 1, "b": 5, "c": 10},
+		activeTxnBegins: map[uint64]int{7: 1},
+	}
+
+	e.evictKeyVersions()
+
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	require.Equal(t, map[string]uint64{"c": 10}, e.keyVersions)
+}
+
+func TestEvictKeyVersionsClearsWhenNoActiveTxn(t *testing.T) {
+	e := &Engine{
+		keyVersions:     map[string]uint64{"a": 1, "b": 2},
+		activeTxnBegins: make(map[uint64]int),
+	}
+
+	e.evictKeyVersions()
+
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	require.Empty(t, e.keyVersions)
+}
+
+func TestRegisterUnregisterTxnBeginCounts(t *testing.T) {
+	e := &Engine{
+		activeTxnBegins: make(map[uint64]int),
+	}
+
+	e.registerTxnBegin(10)
+	e.registerTxnBegin(10)
+	e.registerTxnBegin(20)
+
+	e.mu.RLock()
+	require.Equal(t, map[uint64]int{10: 2, 20: 1}, e.activeTxnBegins)
+	e.mu.RUnlock()
+
+	e.unregisterTxnBegin(10)
+	e.unregisterTxnBegin(10)
+	e.unregisterTxnBegin(20)
+
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	require.Empty(t, e.activeTxnBegins)
+}
+
+func TestEvictKeyVersionsNoopOnEmpty(t *testing.T) {
+	e := &Engine{
+		keyVersions:     make(map[string]uint64),
+		activeTxnBegins: make(map[uint64]int),
+	}
+
+	// should not panic or change anything
+	e.evictKeyVersions()
+
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	require.Empty(t, e.keyVersions)
+	require.Empty(t, e.activeTxnBegins)
+}
+
+func TestRecordKeyVersionsAndConflicts(t *testing.T) {
+	e := &Engine{
+		keyVersions:     make(map[string]uint64),
+		activeTxnBegins: make(map[uint64]int),
+	}
+
+	e.mu.Lock()
+	e.recordKeyVersions([][]byte{[]byte("k1"), []byte("k2")}, 5)
+	e.recordKeyVersions([][]byte{[]byte("k3")}, 10)
+	e.mu.Unlock()
+
+	e.mu.RLock()
+	require.Equal(t, map[string]uint64{"k1": 5, "k2": 5, "k3": 10}, e.keyVersions)
+	e.mu.RUnlock()
+
+	e.mu.RLock()
+	err := e.checkKeyConflicts([][]byte{[]byte("k1")}, 4)
+	e.mu.RUnlock()
+	require.ErrorIs(t, err, ErrTxnConflict)
+
+	e.mu.RLock()
+	err = e.checkKeyConflicts([][]byte{[]byte("k1"), []byte("k2")}, 5)
+	e.mu.RUnlock()
+	require.NoError(t, err)
+
+	e.mu.RLock()
+	err = e.checkKeyConflicts([][]byte{[]byte("unknown")}, 0)
+	e.mu.RUnlock()
+	require.NoError(t, err)
+}
+
+func TestMinActiveTxnBegin(t *testing.T) {
+	e := &Engine{
+		activeTxnBegins: make(map[uint64]int),
+	}
+
+	e.mu.Lock()
+	e.registerTxnBegin(100)
+	e.registerTxnBegin(50)
+	e.registerTxnBegin(75)
+	e.registerTxnBegin(50)
+	min := e.minActiveTxnBegin()
+	e.mu.Unlock()
+
+	require.Equal(t, uint64(50), min)
+
+	e.mu.Lock()
+	e.unregisterTxnBegin(50)
+	e.unregisterTxnBegin(50)
+	e.unregisterTxnBegin(100)
+	e.unregisterTxnBegin(75)
+	min = e.minActiveTxnBegin()
+	e.mu.Unlock()
+
+	require.Equal(t, uint64(math.MaxUint64), min)
 }


### PR DESCRIPTION
Previously, two transactions touching the same key could commit out of order, letting an older txn overwrite a newer value. Now each txn remembers when it started (begin LSN), and at commit it checks the last committed LSN per key. If any key was updated after the txn began—whether by another txn or a non-txn write—the commit fails with ErrTxnConflict. This protects all namespaces (KV, row columns, and LOB/chunked) so newer data can’t be silently overwritten by stale transactions.