### PR TITLE
Standardize HTTP error codes and add idle/expired transaction cleanup

### DIFF
--- a/cmd/unisondb/cliapp/server.go
+++ b/cmd/unisondb/cliapp/server.go
@@ -533,6 +533,9 @@ func (ms *Server) SetupHTTPServer(ctx context.Context) error {
 	httpAPIService := httpapi.NewService(ms.engines)
 	router.HandleFunc("/health", httpAPIService.HandleHealth).Methods(http.MethodGet)
 	httpAPIService.RegisterRoutes(router)
+	ms.DeferCallback = append(ms.DeferCallback, func(ctx context.Context) {
+		httpAPIService.Close()
+	})
 
 	slog.Info("[unisondb.cliapp]",
 		slog.String("event_type", "HTTP.API.registered"),

--- a/dbkernel/txn.go
+++ b/dbkernel/txn.go
@@ -16,6 +16,7 @@ import (
 
 var (
 	ErrTxnAlreadyCommitted      = errors.New("txn already committed")
+	ErrTxnAborted               = errors.New("txn aborted")
 	ErrTxnConflict              = errors.New("txn conflict with newer commit")
 	ErrKeyChangedForChunkedType = errors.New("chunked txn type cannot change key from first value")
 	ErrUnsupportedTxnType       = errors.New("unsupported txn type")
@@ -382,6 +383,12 @@ func (t *Txn) touchedKeys() [][]byte {
 
 func (t *Txn) TxnID() []byte {
 	return t.txnID
+}
+
+// Abort releases txn bookkeeping without committing.
+func (t *Txn) Abort() {
+	t.unregisterBegin()
+	t.err = ErrTxnAborted
 }
 
 func (t *Txn) Checksum() uint32 {

--- a/dbkernel/txn_test.go
+++ b/dbkernel/txn_test.go
@@ -495,6 +495,23 @@ func TestTxnWalLogIndexesPersist(t *testing.T) {
 	}
 }
 
+func TestTxnAbortReleasesBegin(t *testing.T) {
+	baseDir := t.TempDir()
+	namespace := "txn_abort"
+
+	engine, err := dbkernel.NewStorageEngine(baseDir, namespace, dbkernel.NewDefaultEngineConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = engine.Close(context.Background())
+	})
+
+	txn, err := engine.NewTxn(logrecord.LogOperationTypeInsert, logrecord.LogEntryTypeKV)
+	require.NoError(t, err)
+
+	txn.Abort()
+	require.ErrorIs(t, txn.Commit(), dbkernel.ErrTxnAborted)
+}
+
 func readTxnWalRecordLSN(t *testing.T, walog *walfs.WALog, idx uint64) uint64 {
 	t.Helper()
 


### PR DESCRIPTION
1. Centralize HTTP status mapping for engine errors
2. Track transaction last-write time and enforce idle and max-lifetime thresholds. 