### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,4 +520,4 @@ mkcert -key-file grpc.key -cert-file grpc.crt localhost 127.0.0.1 ::1
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ankur-anand/unisondb&type=date&legend=top-left)](https://www.star-history.com/#ankur-anand/unisondb&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=ankur-anand/unisondb&type=date&legend=top-left)](https://star-history.dera.page/#ankur-anand/unisondb&type=date&legend=top-left)


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This change points the chart to star-history.dera.page, which uses an alternative data source requiring no API token, so the chart renders correctly again.